### PR TITLE
docs: use `extends` instead of spreading default theme

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,9 +1,10 @@
-import Theme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+import DefaultTheme from 'vitepress/theme'
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
 
 export default {
-  ...Theme,
+  extends: DefaultTheme,
   enhanceApp({ app }) {
     enhanceAppWithTabs(app)
   }
-}
+} satisfies Theme

--- a/docs/detype/index.md
+++ b/docs/detype/index.md
@@ -45,15 +45,16 @@ export default defineConfig({
 
 ```ts
 // .vitepress/theme/index.ts
-import Theme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+import DefaultTheme from 'vitepress/theme'
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
 
 export default {
-  ...Theme,
+  extends: DefaultTheme,
   enhanceApp({ app }) {
     enhanceAppWithTabs(app)
   }
-}
+} satisfies Theme
 ```
 
 ## Syntax

--- a/docs/npm-commands/index.md
+++ b/docs/npm-commands/index.md
@@ -38,15 +38,16 @@ export default defineConfig({
 
 ```ts
 // .vitepress/theme/index.ts
-import Theme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+import DefaultTheme from 'vitepress/theme'
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
 
 export default {
-  ...Theme,
+  extends: DefaultTheme,
   enhanceApp({ app }) {
     enhanceAppWithTabs(app)
   }
-}
+} satisfies Theme
 ```
 
 ## Syntax

--- a/docs/tabs/index.md
+++ b/docs/tabs/index.md
@@ -34,15 +34,16 @@ export default defineConfig({
 
 ```ts
 // .vitepress/theme/index.ts
-import Theme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+import DefaultTheme from 'vitepress/theme'
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
 
 export default {
-  ...Theme,
+  extends: DefaultTheme,
   enhanceApp({ app }) {
     enhanceAppWithTabs(app)
   }
-}
+} satisfies Theme
 ```
 
 ## Syntax


### PR DESCRIPTION
Spreading the default theme when `enhanceApp` is specified prevents registering some of the vitepress components like badges that other people might be using.