### PR TITLE
fix(tabs): adapt to light theme and prevent codeblock overflow

### DIFF
--- a/.changeset/red-dolphins-tell.md
+++ b/.changeset/red-dolphins-tell.md
@@ -1,0 +1,6 @@
+---
+'vitepress-plugin-tabs': patch
+---
+
+Use `--vp-c-bg` in light mode for code blocks inside tabs to have slight difference between the backgrounds.
+Specify margin and border radius on code blocks inside tabs to prevent them from overflowing on smaller viewport widths.

--- a/packages/vitepress-plugin-tabs/src/client/PluginTabs.vue
+++ b/packages/vitepress-plugin-tabs/src/client/PluginTabs.vue
@@ -139,4 +139,13 @@ provideTabsSingleState({ uid, selected })
 .plugin-tabs--tab[aria-selected='true']::after {
   background-color: var(--vp-plugin-tabs-tab-active-bar-color);
 }
+
+.plugin-tabs div[class*='language-'] {
+  border-radius: 8px;
+  margin: 16px 0;
+}
+
+:root:not(.dark) .plugin-tabs div[class*='language-'] {
+  background-color: var(--vp-c-bg);
+}
 </style>

--- a/packages/vitepress-plugin-tabs/src/client/PluginTabs.vue
+++ b/packages/vitepress-plugin-tabs/src/client/PluginTabs.vue
@@ -139,13 +139,4 @@ provideTabsSingleState({ uid, selected })
 .plugin-tabs--tab[aria-selected='true']::after {
   background-color: var(--vp-plugin-tabs-tab-active-bar-color);
 }
-
-.plugin-tabs div[class*='language-'] {
-  border-radius: 8px;
-  margin: 16px 0;
-}
-
-:root:not(.dark) .plugin-tabs div[class*='language-'] {
-  background-color: var(--vp-c-bg);
-}
 </style>

--- a/packages/vitepress-plugin-tabs/src/client/PluginTabsTab.vue
+++ b/packages/vitepress-plugin-tabs/src/client/PluginTabsTab.vue
@@ -24,15 +24,20 @@ const { uid, selected } = useTabsSingleState()
   padding: 16px;
 }
 
-.plugin-tabs--content > :first-child {
+.plugin-tabs--content > :first-child:first-child {
   margin-top: 0;
 }
 
-.plugin-tabs--content > :last-child {
+.plugin-tabs--content > :last-child:last-child {
   margin-bottom: 0;
 }
 
-.plugin-tabs--content > div[class*='language-'] {
-  margin: 8px 0;
+.plugin-tabs--content > :deep(div[class*='language-']) {
+  border-radius: 8px;
+  margin: 16px 0px;
+}
+
+:root:not(.dark) .plugin-tabs--content :deep(div[class*='language-']) {
+  background-color: var(--vp-c-bg);
 }
 </style>


### PR DESCRIPTION
Before:

<img width="591" alt="image" src="https://github.com/sapphi-red/vitepress-plugins/assets/40380293/e1673028-97b8-42b5-be04-17977da6447d">

After:

<img width="585" alt="image" src="https://github.com/sapphi-red/vitepress-plugins/assets/40380293/e4bc8818-8cef-4ce2-b172-0b91d61d2953">
