### PR TITLE
fix: don't mutate the original env object

### DIFF
--- a/.changeset/cuddly-carpets-confess.md
+++ b/.changeset/cuddly-carpets-confess.md
@@ -1,6 +1,6 @@
 ---
-'vitepress-plugin-npm-commands': minor
-'vitepress-plugin-detype': minor
+'vitepress-plugin-npm-commands': patch
+'vitepress-plugin-detype': patch
 ---
 
-Pass a deep cloned copy of `env` to avoid mutating the original object. Requires node v18.
+Pass a deep cloned copy of `env` to avoid mutating the original object. 

--- a/.changeset/cuddly-carpets-confess.md
+++ b/.changeset/cuddly-carpets-confess.md
@@ -3,4 +3,4 @@
 'vitepress-plugin-detype': patch
 ---
 
-Pass a deep cloned copy of `env` to avoid mutating the original object. 
+Pass a deep cloned copy of `env` to avoid mutating the original object.

--- a/.changeset/cuddly-carpets-confess.md
+++ b/.changeset/cuddly-carpets-confess.md
@@ -1,0 +1,6 @@
+---
+'vitepress-plugin-npm-commands': minor
+'vitepress-plugin-detype': minor
+---
+
+Pass a deep cloned copy of `env` to avoid mutating the original object. Requires node v18.

--- a/docs/detype/index.md
+++ b/docs/detype/index.md
@@ -1,7 +1,3 @@
----
-title: vitepress-plugin-detype
----
-
 # vitepress-plugin-detype
 
 > A plugin that adds syntax for generating js from ts code snippet.

--- a/docs/npm-commands/index.md
+++ b/docs/npm-commands/index.md
@@ -1,7 +1,3 @@
----
-title: vitepress-plugin-npm-commands
----
-
 # vitepress-plugin-npm-commands
 
 > A plugin that adds syntax for showing `npm`, `yarn`, `pnpm`, `bun` commands in tabs.

--- a/docs/tabs/index.md
+++ b/docs/tabs/index.md
@@ -1,7 +1,3 @@
----
-title: vitepress-plugin-tabs
----
-
 # vitepress-plugin-tabs
 
 > A plugin that adds syntax for showing content in tabs.

--- a/packages/vitepress-plugin-detype/package.json
+++ b/packages/vitepress-plugin-detype/package.json
@@ -44,6 +44,7 @@
     "vue": "^3.3.4"
   },
   "dependencies": {
-    "detype": "^0.6.3"
+    "detype": "^0.6.3",
+    "klona": "^2.0.6"
   }
 }

--- a/packages/vitepress-plugin-detype/src/node/markdownPlugin.ts
+++ b/packages/vitepress-plugin-detype/src/node/markdownPlugin.ts
@@ -63,7 +63,7 @@ export const detypePlugin = (
           const langForRender = getLangForRender(type, lang)
           const codeWithFence =
             `${token.markup}${langForRender}${attrs}\n` + content + token.markup
-          return { result: md.render(codeWithFence, env) }
+          return { result: md.render(codeWithFence, structuredClone(env)) }
         } catch (e) {
           return { error: e }
         }

--- a/packages/vitepress-plugin-detype/src/node/markdownPlugin.ts
+++ b/packages/vitepress-plugin-detype/src/node/markdownPlugin.ts
@@ -4,6 +4,7 @@ import type { PrettierOptions } from 'detype'
 import type { ContentMap } from './contentMap'
 import type { SupportedType } from './parseDetypeInfo'
 import { parseDetypeInfo } from './parseDetypeInfo'
+import { klona } from 'klona'
 
 const tabsShareStateKey = '~detype'
 const langs = ['ts', 'js'] as const
@@ -63,7 +64,7 @@ export const detypePlugin = (
           const langForRender = getLangForRender(type, lang)
           const codeWithFence =
             `${token.markup}${langForRender}${attrs}\n` + content + token.markup
-          return { result: md.render(codeWithFence, structuredClone(env)) }
+          return { result: md.render(codeWithFence, klona(env)) }
         } catch (e) {
           return { error: e }
         }

--- a/packages/vitepress-plugin-npm-commands/package.json
+++ b/packages/vitepress-plugin-npm-commands/package.json
@@ -41,6 +41,7 @@
     "tsup": "^7.2.0"
   },
   "dependencies": {
+    "klona": "^2.0.6",
     "npm-to-yarn": "^2.1.0"
   }
 }

--- a/packages/vitepress-plugin-npm-commands/src/node/markdownPlugin.ts
+++ b/packages/vitepress-plugin-npm-commands/src/node/markdownPlugin.ts
@@ -2,6 +2,7 @@ import type MarkdownIt from 'markdown-it'
 import convert from 'npm-to-yarn'
 import type { PackageManager } from './packageManager'
 import { packageManagers } from './packageManager'
+import { klona } from 'klona'
 
 const tabsShareStateKey = '~npm-commands'
 const npmCommandsCommandRE = new RegExp(
@@ -40,7 +41,7 @@ export const npmCommandsPlugin = (md: MarkdownIt) => {
         `${token.markup}${token.info}${attrStr}\n` + code + token.markup
       return `<PluginTabsTab label="${pkgManger}">${md.render(
         codeWithFence,
-        structuredClone(env)
+        klona(env)
       )}</PluginTabsTab>`
     })
 

--- a/packages/vitepress-plugin-npm-commands/src/node/markdownPlugin.ts
+++ b/packages/vitepress-plugin-npm-commands/src/node/markdownPlugin.ts
@@ -40,7 +40,7 @@ export const npmCommandsPlugin = (md: MarkdownIt) => {
         `${token.markup}${token.info}${attrStr}\n` + code + token.markup
       return `<PluginTabsTab label="${pkgManger}">${md.render(
         codeWithFence,
-        env
+        structuredClone(env)
       )}</PluginTabsTab>`
     })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       detype:
         specifier: ^0.6.3
         version: 0.6.3
+      klona:
+        specifier: ^2.0.6
+        version: 2.0.6
     devDependencies:
       '@types/markdown-it':
         specifier: ^13.0.1
@@ -105,6 +108,9 @@ importers:
 
   packages/vitepress-plugin-npm-commands:
     dependencies:
+      klona:
+        specifier: ^2.0.6
+        version: 2.0.6
       npm-to-yarn:
         specifier: ^2.1.0
         version: 2.1.0
@@ -3218,6 +3224,11 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
     dev: true
+
+  /klona@2.0.6:
+    resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
+    engines: {node: '>= 8'}
+    dev: false
 
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}


### PR DESCRIPTION
Things like `env.title` were being overwritten because the original object was being passed. Using `structuredClone` would prevent using this on StackBlitz temporarily. We can just spread `env` if you want to keep this running on v16. It won't be the safest solution, but would work better than passing the original one.