### PR TITLE
docs: prevent layout shift and unexpected clickable area

### DIFF
--- a/docs/.vitepress/theme/components/VersionBadge.vue
+++ b/docs/.vitepress/theme/components/VersionBadge.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+defineProps<{
+  package: string
+}>()
+</script>
+
+<template>
+  <a
+    href="https://www.npmjs.com/package/vitepress-plugin-detype"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <img
+      src="https://img.shields.io/npm/v/vitepress-plugin-detype.svg"
+      alt="NPM version"
+    />
+  </a>
+</template>
+
+<style scoped>
+a {
+  display: inline-block;
+  height: 20px;
+}
+</style>

--- a/docs/.vitepress/theme/components/VersionBadge.vue
+++ b/docs/.vitepress/theme/components/VersionBadge.vue
@@ -6,12 +6,12 @@ defineProps<{
 
 <template>
   <a
-    href="https://www.npmjs.com/package/vitepress-plugin-detype"
+    :href="`https://www.npmjs.com/package/${package}`"
     target="_blank"
     rel="noopener noreferrer"
   >
     <img
-      src="https://img.shields.io/npm/v/vitepress-plugin-detype.svg"
+      :src="`https://img.shields.io/npm/v/${package}.svg`"
       alt="NPM version"
     />
   </a>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,9 +1,11 @@
 import Theme from 'vitepress/theme'
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
+import VersionBadge from './components/VersionBadge.vue'
 
 export default {
   ...Theme,
   enhanceApp({ app }) {
     enhanceAppWithTabs(app)
+    app.component('VersionBadge', VersionBadge)
   }
 }

--- a/docs/detype/index.md
+++ b/docs/detype/index.md
@@ -6,7 +6,7 @@ title: vitepress-plugin-detype
 
 > A plugin that adds syntax for generating js from ts code snippet.
 
-[![NPM version](https://img.shields.io/npm/v/vitepress-plugin-detype.svg)](https://www.npmjs.com/package/vitepress-plugin-detype)
+<version-badge package="vitepress-plugin-detype" />
 
 This plugin uses [`detype`](https://github.com/cyco130/detype) to transform TypeScript to JavaScript.
 

--- a/docs/npm-commands/index.md
+++ b/docs/npm-commands/index.md
@@ -6,7 +6,7 @@ title: vitepress-plugin-npm-commands
 
 > A plugin that adds syntax for showing `npm`, `yarn`, `pnpm`, `bun` commands in tabs.
 
-[![NPM version](https://img.shields.io/npm/v/vitepress-plugin-tabs.svg)](https://www.npmjs.com/package/vitepress-plugin-npm-commands)
+<version-badge package="vitepress-plugin-npm-commands" />
 
 ## Installation
 

--- a/docs/tabs/index.md
+++ b/docs/tabs/index.md
@@ -6,7 +6,7 @@ title: vitepress-plugin-tabs
 
 > A plugin that adds syntax for showing content in tabs.
 
-[![NPM version](https://img.shields.io/npm/v/vitepress-plugin-tabs.svg)](https://www.npmjs.com/package/vitepress-plugin-tabs)
+<version-badge package="vitepress-plugin-tabs" />
 
 ## Installation
 


### PR DESCRIPTION
this whole area was clickable:

<img width="578" alt="image" src="https://github.com/sapphi-red/vitepress-plugins/assets/40380293/45fe0fea-84b4-4a46-863e-5b7f2be95cf8">

also, since the height wasn't fixed, it was causing layout shifts on load