### PR TITLE
fix: replace incremental ids with vue's useId to ensure stable IDs across builds

### DIFF
--- a/.changeset/eight-roses-destroy.md
+++ b/.changeset/eight-roses-destroy.md
@@ -1,0 +1,5 @@
+---
+'vitepress-plugin-tabs': patch
+---
+
+replace incremental ids with vue's useId to ensure stable IDs across builds

--- a/packages/vitepress-plugin-tabs/package.json
+++ b/packages/vitepress-plugin-tabs/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://vitepress-plugins.sapphi.red/tabs/",
   "peerDependencies": {
     "vitepress": "^1.0.0",
-    "vue": "^3.3.8"
+    "vue": "^3.5"
   },
   "devDependencies": {
     "@types/markdown-it": "^14.1.2",

--- a/packages/vitepress-plugin-tabs/src/client/PluginTabs.vue
+++ b/packages/vitepress-plugin-tabs/src/client/PluginTabs.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { ref, toRef } from 'vue'
+import { ref, toRef, useId } from 'vue'
 import { useStabilizeScrollPosition } from './useStabilizeScrollPosition'
 import { useTabsSelectedState } from './useTabsSelectedState'
-import { useUid } from './useUid'
 import { useTabLabels } from './useTabLabels'
 import { provideTabsSingleState } from './useTabsSingleState'
 import { useIsPrint } from './useIsPrint'
@@ -42,7 +41,7 @@ const onKeydown = (e: KeyboardEvent) => {
   }
 }
 
-const uid = useUid()
+const uid = useId()
 
 provideTabsSingleState({ uid, selected })
 </script>

--- a/packages/vitepress-plugin-tabs/src/client/useUid.ts
+++ b/packages/vitepress-plugin-tabs/src/client/useUid.ts
@@ -1,6 +1,0 @@
-let id = 0
-
-export const useUid = () => {
-  id++
-  return '' + id
-}


### PR DESCRIPTION
x-ref: https://github.com/vuejs/vitepress/issues/4677

The ids were changing between builds even if no content was modified, probably because of async rendering somewhere.

<img width="1273" alt="image" src="https://github.com/user-attachments/assets/b2b757c0-f295-4c7a-b7d2-46da633ff7b2" />

---

probably can be minor instead of patch since peer dependency range is updated