### PR TITLE
Sync tabs with a `key:` shared state to URL query parameters

### DIFF
--- a/.changeset/tabs-url-sync.md
+++ b/.changeset/tabs-url-sync.md
@@ -1,0 +1,5 @@
+---
+'vitepress-plugin-tabs': minor
+---
+
+Sync tabs with a `key:` shared state to URL query parameters. Sharing a link like `?ab=tab%20b` pre-selects the matching tab on load, and clicking a tab updates the URL via `history.replaceState` so the URL always reflects the visible tab.

--- a/docs/tabs/index.md
+++ b/docs/tabs/index.md
@@ -108,6 +108,8 @@ a content 2
 b content 2
 :::
 
+Tabs with a `key:` are also synced to the URL query string. Sharing a link like `?ab=tab%20b` opens the page with `tab b` pre-selected, and clicking a tab updates the URL (via `history.replaceState`) so the current URL always reflects the visible tab.
+
 ### Code variant
 
 Use `variant:code` to style tabs like VitePress's built-in [code groups](https://vitepress.dev/guide/markdown#code-groups). This is useful when your tab content is primarily code blocks.

--- a/packages/vitepress-plugin-tabs/src/client/useTabsSelectedState.ts
+++ b/packages/vitepress-plugin-tabs/src/client/useTabsSelectedState.ts
@@ -24,6 +24,18 @@ const setLocalStorageValue = (v: TabsSharedStateContent) => {
   ls.setItem(localStorageKey, JSON.stringify(v))
 }
 
+const getUrlParamValue = (key: string): string | null => {
+  if (typeof location === 'undefined') return null
+  return new URLSearchParams(location.search).get(key)
+}
+const setUrlParamValue = (key: string, value: string) => {
+  if (typeof location === 'undefined' || typeof history === 'undefined') return
+  const url = new URL(location.href)
+  if (url.searchParams.get(key) === value) return
+  url.searchParams.set(key, value)
+  history.replaceState(history.state, '', url.toString())
+}
+
 export const provideTabsSharedState = (app: App) => {
   const state = reactive<TabsSharedState>({})
   watch(
@@ -53,6 +65,13 @@ export const useTabsSelectedState = <T extends string>(
     if (!sharedState.content) {
       sharedState.content = getLocalStorageValue()
     }
+    const key = sharedStateKey.value
+    if (key && sharedState.content) {
+      const urlValue = getUrlParamValue(key)
+      if (urlValue !== null && (acceptValues.value as string[]).includes(urlValue)) {
+        sharedState.content[key] = urlValue
+      }
+    }
   })
 
   const nonSharedState = ref<T | undefined>()
@@ -80,6 +99,7 @@ export const useTabsSelectedState = <T extends string>(
         if (sharedState.content) {
           sharedState.content[key] = v
         }
+        setUrlParamValue(key, v)
       } else {
         nonSharedState.value = v
       }


### PR DESCRIPTION
https://github.com/sapphi-red/vitepress-plugins/discussions/95

Sync tab selection to the URL query string for tab groups that use a shared state key (`:::tabs key:xxx`). This allows sharing links that pre-select a specific tab.

-  On mount, if the URL has a query param whose name matches the tab group's `sharedStateKey` and whose value matches a tab label, that tab is pre-selected. Unknown or invalid values fall through to the existing localStorage / first-tab fallback.
- Clicking a tab updates the URL via `history.replaceState`, so the URL bar always reflects the visible tab.
- Tabs without a `key:` are unchanged as they have no stable identifier.