### PR TITLE
fix(tabs): restore code block background for variant:code

### DIFF
--- a/.changeset/tender-groups-hear.md
+++ b/.changeset/tender-groups-hear.md
@@ -1,0 +1,5 @@
+---
+"vitepress-plugin-tabs": patch
+---
+
+Restore light-theme code block background for variant:code

--- a/packages/vitepress-plugin-tabs/src/client/PluginTabsTab.vue
+++ b/packages/vitepress-plugin-tabs/src/client/PluginTabsTab.vue
@@ -45,7 +45,10 @@ const isPrint = useIsPrint()
   margin: 16px 0px;
 }
 
-:root:not(.dark) .plugin-tabs--content :deep(div[class*='language-']) {
+:root:not(.dark)
+  .plugin-tabs:not([data-variant='code'])
+  .plugin-tabs--content
+  :deep(div[class*='language-']) {
   background-color: var(--vp-c-bg);
 }
 


### PR DESCRIPTION
The commit b30ae9011a83cc76248c29ff2154240a4db43a5b added a different background for code blocks in light theme. This was done to distinguish code blocks from the same background of the tab panel. However, that made the background color the same as the page, which again made code blocks indistinguishable from the background with `variant:code`. Fix this by applying the background only to tabs without `variant:code`.

before:
<img width="128" height="103" alt="image" src="https://github.com/user-attachments/assets/1f00a493-dacb-408d-acea-56ded7b30653" />

after:
<img width="168" height="100" alt="image" src="https://github.com/user-attachments/assets/7b4883e4-93f0-4006-820c-8b267ea9c694" />